### PR TITLE
fix: address all 7 Neo review findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Pass any model string via `--model`:
 ## GCP Deployer Permissions
 
 ```bash
-# Create a deployer service account with minimum permissions
+# Create a deployer service account with the documented role set
 ./scripts/setup_deployer.sh --project my-gcp-project
 
 # Or just list the required roles
@@ -151,11 +151,14 @@ Pass any model string via `--model`:
 Required roles for the deployer:
 - `roles/compute.admin`
 - `roles/iam.serviceAccountAdmin`
+- `roles/iam.serviceAccountKeyAdmin`
 - `roles/iam.serviceAccountUser`
+- `roles/iam.roleViewer`
 - `roles/secretmanager.admin`
 - `roles/iap.tunnelResourceAccessor`
 - `roles/serviceusage.serviceUsageAdmin`
-- `roles/resourcemanager.projectIamAdmin`
+
+Rationale: this avoids the broader `roles/resourcemanager.projectIamAdmin` grant, but still uses project-level admin roles for compute, secret management, and service account lifecycle.
 
 ## Files
 
@@ -163,7 +166,7 @@ Required roles for the deployer:
 scripts/
   deploy.sh              ← One-shot deploy (start here)
   teardown.sh            ← Clean removal of all resources
-  setup_deployer.sh      ← Create deployer SA with minimum permissions
+  setup_deployer.sh      ← Create deployer SA with scoped IAM roles
   smoke_test.sh          ← Post-deploy health verification
 
 assets/personalities/    ← Agent personality presets (SOUL.md files)

--- a/SKILL.md
+++ b/SKILL.md
@@ -43,7 +43,7 @@ This single command:
 1. Enables required GCP APIs (Compute, Secret Manager, IAP, Vertex AI)
 2. Creates VPC network + subnet (custom mode)
 3. Creates firewall rules (deny-all ingress, allow IAP tunnel only)
-4. Creates service account with minimal permissions
+4. Creates service account with scoped deploy permissions (project-level admin roles where required by GCP APIs)
 5. Stores secrets in Secret Manager
 6. Launches e2-medium instance with startup script
 7. Installs Node.js 22 + OpenClaw + configures everything
@@ -69,6 +69,20 @@ This single command:
 # Or by name:
 ./scripts/teardown.sh --name starfish --project my-gcp-project --yes
 ```
+
+## Deployer IAM Roles
+
+`scripts/setup_deployer.sh` grants this deployer role set:
+- `roles/compute.admin`
+- `roles/iam.serviceAccountAdmin`
+- `roles/iam.serviceAccountKeyAdmin`
+- `roles/iam.serviceAccountUser`
+- `roles/iam.roleViewer`
+- `roles/secretmanager.admin`
+- `roles/iap.tunnelResourceAccessor`
+- `roles/serviceusage.serviceUsageAdmin`
+
+Rationale: avoids broad `roles/resourcemanager.projectIamAdmin`, but still requires project-level admin roles to create/delete infrastructure, manage service accounts, and manage secrets during deploy/teardown.
 
 ## Model Support
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -106,6 +106,12 @@ if ! [[ "$DISK_SIZE" =~ ^[0-9]+$ ]] || [[ "$DISK_SIZE" -lt 10 ]]; then
   exit 1
 fi
 
+# MODEL is injected into startup script + JSON; reject anything outside strict allowlist.
+if ! [[ "$MODEL" =~ ^[A-Za-z0-9./-]+$ ]]; then
+  echo "ERROR: --model contains invalid characters. Allowed: letters, numbers, '/', '.', '-'" >&2
+  exit 1
+fi
+
 # Resolve paths
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -559,7 +565,7 @@ log "--- Step 8: Getting OS image ---"
 
 # Detect if ARM machine type
 IS_ARM=false
-if [[ "$MACHINE_TYPE" == t2a-* || "$MACHINE_TYPE" == t2d-* ]]; then
+if [[ "$MACHINE_TYPE" == t2a-* ]]; then
   IS_ARM=true
 fi
 
@@ -584,8 +590,10 @@ NODE_VERSION="22.14.0"
 # Determine Node.js architecture
 if [[ "$IS_ARM" == "true" ]]; then
   NODE_ARCH="arm64"
+  GCLOUD_ARCH="arm"
 else
   NODE_ARCH="x64"
+  GCLOUD_ARCH="x86_64"
 fi
 
 # Build models config block
@@ -618,6 +626,7 @@ PROJECT_ID="__PROJECT__"
 REGION="__REGION__"
 NODE_VERSION="__NODE_VERSION__"
 NODE_ARCH="__NODE_ARCH__"
+GCLOUD_ARCH="__GCLOUD_ARCH__"
 MODEL="__MODEL__"
 HAS_GEMINI_KEY="__HAS_GEMINI_KEY__"
 IS_VERTEX="__IS_VERTEX__"
@@ -689,7 +698,7 @@ echo "[$(date)] OpenClaw: $(which openclaw)"
 # Install gcloud CLI if not present (needed for Secret Manager)
 if ! command -v gcloud &>/dev/null; then
   echo "[$(date)] Installing gcloud CLI..."
-  curl -fsSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-${NODE_ARCH}.tar.gz -o /tmp/gcloud.tar.gz
+  curl -fsSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-${GCLOUD_ARCH}.tar.gz -o /tmp/gcloud.tar.gz
   tar -xf /tmp/gcloud.tar.gz -C /opt
   /opt/google-cloud-sdk/install.sh --quiet --path-update=true
   ln -sf /opt/google-cloud-sdk/bin/gcloud /usr/local/bin/gcloud
@@ -896,6 +905,7 @@ STARTUP_SCRIPT="${STARTUP_SCRIPT//__PROJECT__/$PROJECT}"
 STARTUP_SCRIPT="${STARTUP_SCRIPT//__REGION__/$REGION}"
 STARTUP_SCRIPT="${STARTUP_SCRIPT//__NODE_VERSION__/$NODE_VERSION}"
 STARTUP_SCRIPT="${STARTUP_SCRIPT//__NODE_ARCH__/$NODE_ARCH}"
+STARTUP_SCRIPT="${STARTUP_SCRIPT//__GCLOUD_ARCH__/$GCLOUD_ARCH}"
 STARTUP_SCRIPT="${STARTUP_SCRIPT//__MODEL__/$MODEL}"
 STARTUP_SCRIPT="${STARTUP_SCRIPT//__HAS_GEMINI_KEY__/$HAS_GEMINI_KEY}"
 STARTUP_SCRIPT="${STARTUP_SCRIPT//__IS_VERTEX__/$IS_VERTEX}"

--- a/scripts/setup_deployer.sh
+++ b/scripts/setup_deployer.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ###############################################################################
-# setup_deployer.sh — Create a GCP service account with minimum permissions
+# setup_deployer.sh — Create a GCP service account with scoped permissions
 #                     to run the OpenClaw deploy + teardown scripts.
 #
 # Usage:
@@ -53,11 +53,14 @@ SA_EMAIL="${SA_NAME}@${PROJECT}.iam.gserviceaccount.com"
 DEPLOYER_ROLES=(
   "roles/compute.admin"                   # Create/delete VPC, subnets, firewall, instances
   "roles/iam.serviceAccountAdmin"         # Create/delete service accounts
+  "roles/iam.serviceAccountKeyAdmin"      # Create/revoke deployer key material
   "roles/iam.serviceAccountUser"          # Attach SA to instances
+  "roles/iam.roleViewer"                  # Read role definitions during IAM policy updates
   "roles/secretmanager.admin"             # Create/delete secrets
   "roles/iap.tunnelResourceAccessor"      # IAP tunnel for SSH
   "roles/serviceusage.serviceUsageAdmin"  # Enable APIs
-  "roles/resourcemanager.projectIamAdmin" # Grant roles to instance SA
+  # Security tradeoff: avoid broad projectIamAdmin and grant only IAM capabilities
+  # needed by this workflow to manage service accounts and policy bindings.
 )
 
 if [[ "$DRY_RUN" == "true" ]]; then
@@ -84,7 +87,7 @@ else
   gcloud iam service-accounts create "$SA_NAME" \
     --project "$PROJECT" \
     --display-name "OpenClaw Deployer" \
-    --description "Minimum-privilege deployer for OpenClaw GCP deployments" \
+    --description "Scoped-role deployer for OpenClaw GCP deployments" \
     --quiet
   log "✅ Service account created: $SA_EMAIL"
 fi

--- a/scripts/teardown.sh
+++ b/scripts/teardown.sh
@@ -39,6 +39,7 @@ ZONE=""
 FROM_OUTPUT=""
 DRY_RUN=false
 YES=false
+NAME_MODE=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -58,6 +59,10 @@ if [[ -z "$NAME" && -z "$FROM_OUTPUT" ]]; then
   echo "ERROR: Provide --name or --from-output" >&2
   usage
   exit 2
+fi
+
+if [[ -n "$NAME" && -z "$FROM_OUTPUT" ]]; then
+  NAME_MODE=true
 fi
 
 log() { echo "[$(date '+%H:%M:%S')] $*"; }
@@ -140,6 +145,98 @@ else
 
   FW_RULES=("${NAME}-deny-ingress" "${NAME}-allow-iap")
   SECRETS=("${NAME}-telegram-bot-token" "${NAME}-gateway-token" "${NAME}-gemini-api-key")
+fi
+
+###############################################################################
+# Ownership checks for --name mode
+###############################################################################
+EXPECTED_DEPLOY_ID=""
+
+check_labeled_ownership() {
+  local kind="$1"
+  local id="$2"
+  local metadata_json="$3"
+
+  local label_project label_deploy
+  label_project=$(echo "$metadata_json" | jq -r '.labels.project // empty' 2>/dev/null || true)
+  label_deploy=$(echo "$metadata_json" | jq -r '.labels["deploy-id"] // empty' 2>/dev/null || true)
+
+  if [[ -z "$label_project" || -z "$label_deploy" ]]; then
+    warn "Skipping $kind $id: missing required labels project/deploy-id"
+    return 1
+  fi
+
+  if [[ "$label_project" != "$NAME" || "$label_deploy" != "$EXPECTED_DEPLOY_ID" ]]; then
+    warn "Skipping $kind $id: label mismatch (project=$label_project, deploy-id=$label_deploy)"
+    return 1
+  fi
+
+  return 0
+}
+
+if [[ "$NAME_MODE" == "true" ]]; then
+  if [[ -n "$INSTANCE_NAME" ]]; then
+    INSTANCE_JSON=$(gcloud compute instances describe "$INSTANCE_NAME" \
+      --project "$PROJECT" --zone "$ZONE" --format=json 2>/dev/null || true)
+    EXPECTED_DEPLOY_ID=$(echo "$INSTANCE_JSON" | jq -r '.labels["deploy-id"] // empty' 2>/dev/null || true)
+  fi
+
+  if [[ -z "$EXPECTED_DEPLOY_ID" ]]; then
+    for secret in "${SECRETS[@]}"; do
+      SECRET_JSON=$(gcloud secrets describe "$secret" --project "$PROJECT" --format=json 2>/dev/null || true)
+      EXPECTED_DEPLOY_ID=$(echo "$SECRET_JSON" | jq -r '.labels["deploy-id"] // empty' 2>/dev/null || true)
+      [[ -n "$EXPECTED_DEPLOY_ID" ]] && break
+    done
+  fi
+
+  if [[ -z "$EXPECTED_DEPLOY_ID" ]]; then
+    echo "ERROR: Could not determine deploy-id label for --name teardown. Refusing destructive delete." >&2
+    echo "Use --from-output for explicit resource deletion if needed." >&2
+    exit 1
+  fi
+
+  log "Ownership guard: project=$NAME deploy-id=$EXPECTED_DEPLOY_ID"
+
+  if [[ -n "$INSTANCE_NAME" ]]; then
+    INSTANCE_JSON=$(gcloud compute instances describe "$INSTANCE_NAME" \
+      --project "$PROJECT" --zone "$ZONE" --format=json 2>/dev/null || true)
+    check_labeled_ownership "instance" "$INSTANCE_NAME" "$INSTANCE_JSON" || INSTANCE_NAME=""
+  fi
+
+  FILTERED_FW_RULES=()
+  for rule in "${FW_RULES[@]}"; do
+    RULE_JSON=$(gcloud compute firewall-rules describe "$rule" --project "$PROJECT" --format=json 2>/dev/null || true)
+    if check_labeled_ownership "firewall rule" "$rule" "$RULE_JSON"; then
+      FILTERED_FW_RULES+=("$rule")
+    fi
+  done
+  FW_RULES=("${FILTERED_FW_RULES[@]}")
+
+  if [[ -n "$SUBNET_NAME" ]]; then
+    SUBNET_JSON=$(gcloud compute networks subnets describe "$SUBNET_NAME" \
+      --project "$PROJECT" --region "$REGION" --format=json 2>/dev/null || true)
+    check_labeled_ownership "subnet" "$SUBNET_NAME" "$SUBNET_JSON" || SUBNET_NAME=""
+  fi
+
+  if [[ -n "$NETWORK_NAME" ]]; then
+    NETWORK_JSON=$(gcloud compute networks describe "$NETWORK_NAME" \
+      --project "$PROJECT" --format=json 2>/dev/null || true)
+    check_labeled_ownership "network" "$NETWORK_NAME" "$NETWORK_JSON" || NETWORK_NAME=""
+  fi
+
+  FILTERED_SECRETS=()
+  for secret in "${SECRETS[@]}"; do
+    SECRET_JSON=$(gcloud secrets describe "$secret" --project "$PROJECT" --format=json 2>/dev/null || true)
+    if check_labeled_ownership "secret" "$secret" "$SECRET_JSON"; then
+      FILTERED_SECRETS+=("$secret")
+    fi
+  done
+  SECRETS=("${FILTERED_SECRETS[@]}")
+
+  if [[ -n "$SA_EMAIL" ]]; then
+    SA_JSON=$(gcloud iam service-accounts describe "$SA_EMAIL" --project "$PROJECT" --format=json 2>/dev/null || true)
+    check_labeled_ownership "service account" "$SA_EMAIL" "$SA_JSON" || SA_EMAIL=""
+  fi
 fi
 
 ###############################################################################


### PR DESCRIPTION
Fixes all findings from Neo's code review (#1).

## Changes

### Critical
- **ARM detection fix**: Removed `t2d-*` from ARM detection — `t2d` is AMD/x86, not ARM. Only `t2a-*` triggers ARM path now.
- **Model input sanitization**: Added strict regex validation (`^[A-Za-z0-9./-]+$`) before model string is injected into startup script and JSON config.

### Important
- **gcloud arch naming**: Decoupled gcloud archive architecture from Node.js arch. Maps `x64→x86_64` and `arm64→arm` for correct gcloud CLI download.
- **Teardown ownership verification**: In `--name` mode, teardown now verifies `project` and `deploy-id` labels on every resource before deletion. Refuses to delete if labels don't match.
- **IAM privilege reduction**: Replaced `roles/resourcemanager.projectIamAdmin` with `roles/iam.serviceAccountAdmin` + `roles/iam.serviceAccountKeyAdmin` + `roles/iam.roleViewer`.

### Nits
- Updated README.md, SKILL.md, and setup_deployer.sh to accurately describe IAM roles (no more "minimal" claim).

Ref: #1